### PR TITLE
Fix some type issues

### DIFF
--- a/src/repoproviders/doi.py
+++ b/src/repoproviders/doi.py
@@ -39,7 +39,9 @@ class FigshareDataset:
 
 
 @dataclass
-class ImmutableFigshareDataset(FigshareDataset):
+class ImmutableFigshareDataset:
+    installation: FigshareInstallation
+    articleId: int
     # version will always be present when immutable
     version: int
 
@@ -305,7 +307,7 @@ class FigshareResolver:
             return None
 
 
-class ImmutableFigshareResolver(FigshareResolver):
+class ImmutableFigshareResolver:
     async def resolve(
         self, question: FigshareDataset
     ) -> ImmutableFigshareDataset | NotFound | None:

--- a/tests/unit/test_resolvers.py
+++ b/tests/unit/test_resolvers.py
@@ -60,10 +60,7 @@ from repoproviders.git import Git, GitHubResolver, ImmutableGit, ImmutableGitRes
         ),
         (
             "https://github.com/yuvipanda/does-not-exist-e43",
-            Git(
-                repo="https://github.com/yuvipanda/does-not-exist-e43",
-                ref="HEAD"
-            ),
+            Git(repo="https://github.com/yuvipanda/does-not-exist-e43", ref="HEAD"),
         ),
     ),
 )
@@ -98,10 +95,7 @@ async def test_github(url, expected):
         ),
         # Repo doesn't exist
         (
-            Git(
-                repo="https://github.com/yuvipanda/does-not-exist-e43",
-                ref="HEAD"
-            ),
+            Git(repo="https://github.com/yuvipanda/does-not-exist-e43", ref="HEAD"),
             NotFound(),
         ),
         # Ref doesn't exist
@@ -377,7 +371,7 @@ async def test_figshare(url, expected):
                 97827778384384634634634863463434343,
                 None,
             ),
-            NotFound()
+            NotFound(),
         ),
     ),
 )


### PR DESCRIPTION
- mypy correctly points out that inheriting ImmutableFigshareResolver from FigshareResolver is problematic, as you can't use an ImmutableFigshareResolver everywhere you can a FigshareResolver without the calling code having to now also handle a NotFound. This points to the issue of figuring out who validates wether something is NotFound or not. But in simpler terms, we can actually just remove the inheritence here as nothing in the subclass is used, as FigshareDataset is now self containe!
- Don't make ImmutableFigShareDataset inherit from FigShareDataset, as that also violates the substitution principle. Makes sense - these are two distinct types. Figure out what that means for Git and ImmutableGit too.