### PR TITLE
Introduce `Exists | DoesNotExist | MaybeExists` pattern

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.10"]
+        python-version: ["3.11"]
 
     steps:
       - uses: actions/checkout@v4
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.10", "3.13"]
+        python-version: ["3.11", "3.13"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.11"]
+        python-version: ["3.12"]
 
     steps:
       - uses: actions/checkout@v4
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.11", "3.13"]
+        python-version: ["3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,7 +152,7 @@ dependencies = [
 check = "mypy src/repoproviders"
 [tool.hatch.envs.docs]
 description = """Build or serve the documentation."""
-python = "3.10"
+python = "3.11"
 dependencies = [
     "pydata_sphinx_theme ~=0.16",
     "myst-parser ~=4.0",
@@ -190,7 +190,7 @@ extra-dependencies = [
 ]
 
 [[tool.hatch.envs.test.matrix]]
-python = ["3.10", "3.11", "3.12", "3.13"]
+python = ["3.11", "3.12", "3.13"]
 
 [tool.hatch.envs.test.scripts]
 run = "pytest {args:--cov=repoproviders --cov-report=term-missing --cov-report=xml}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,7 +152,7 @@ dependencies = [
 check = "mypy src/repoproviders"
 [tool.hatch.envs.docs]
 description = """Build or serve the documentation."""
-python = "3.11"
+python = "3.12"
 dependencies = [
     "pydata_sphinx_theme ~=0.16",
     "myst-parser ~=4.0",
@@ -190,7 +190,7 @@ extra-dependencies = [
 ]
 
 [[tool.hatch.envs.test.matrix]]
-python = ["3.11", "3.12", "3.13"]
+python = ["3.12", "3.13"]
 
 [tool.hatch.envs.test.scripts]
 run = "pytest {args:--cov=repoproviders --cov-report=term-missing --cov-report=xml}"

--- a/src/repoproviders/__main__.py
+++ b/src/repoproviders/__main__.py
@@ -3,6 +3,8 @@ import asyncio
 import sys
 from pathlib import Path
 
+from repoproviders.resolvers.base import DoesNotExist, Exists, MaybeExists
+
 from .fetchers import fetch
 from .resolvers import resolve
 
@@ -57,7 +59,15 @@ async def main():
         answers = await resolve(args.question, recursive=True)
         if answers:
             last_answer = answers[-1]
-            await fetch(last_answer, Path(args.output_dir))
+            match last_answer:
+                case Exists(repo) | MaybeExists(repo):
+                    await fetch(repo, Path(args.output_dir))
+                case DoesNotExist(message):
+                    print(
+                        message,
+                        file=sys.stderr,
+                    )
+                    sys.exit(1)
         else:
             print(f"Unable to resolve {args.question}")
 

--- a/src/repoproviders/__main__.py
+++ b/src/repoproviders/__main__.py
@@ -62,9 +62,9 @@ async def main():
             match last_answer:
                 case Exists(repo) | MaybeExists(repo):
                     await fetch(repo, Path(args.output_dir))
-                case DoesNotExist(message):
+                case DoesNotExist(kind, message):
                     print(
-                        message,
+                        f"{args.question} detected to be of kind {kind.__name__} but does not exist: {message}",
                         file=sys.stderr,
                     )
                     sys.exit(1)

--- a/src/repoproviders/resolvers/base.py
+++ b/src/repoproviders/resolvers/base.py
@@ -8,6 +8,10 @@ class DoesNotExist[T: Repo]:
     Resolver recognizes this question, but while resolving determined it does not exist
     """
 
+    # womp womp, we can't really retrieve the value of T at runtime so gotta still pass
+    # that in.
+    # FIXME: See if we can enforce somehow that kind is also a `Repo`
+    kind: type
     message: str
 
 

--- a/src/repoproviders/resolvers/base.py
+++ b/src/repoproviders/resolvers/base.py
@@ -3,12 +3,22 @@ from typing import Any, Protocol
 
 
 @dataclass(frozen=True)
-class NotFound[T: Repo]:
+class DoesNotExist[T: Repo]:
     """
     Resolver recognizes this question, but while resolving determined it does not exist
     """
 
     message: str
+
+
+@dataclass(frozen=True)
+class Exists[T: Repo]:
+    repo: T
+
+
+@dataclass(frozen=True)
+class MaybeExists[T: Repo]:
+    repo: T
 
 
 class Repo(Protocol):
@@ -25,5 +35,7 @@ class Repo(Protocol):
 
 
 class SupportsResolve(Protocol):
-    async def resolve(self, question: Any) -> Repo | NotFound | None:
+    async def resolve(
+        self, question: Any
+    ) -> Exists | DoesNotExist | MaybeExists | None:
         pass

--- a/src/repoproviders/resolvers/doi.py
+++ b/src/repoproviders/resolvers/doi.py
@@ -97,7 +97,7 @@ class DoiResolver:
 
             if resp.status == 404:
                 # This is a validly *formatted* DOI, but it's not actually a dOI
-                return DoesNotExist[Doi](f"{doi} is not a registered DOI or handle")
+                return DoesNotExist(Doi, f"{doi} is not a registered DOI or handle")
             elif resp.status == 200:
                 data = await resp.json()
 
@@ -107,7 +107,7 @@ class DoiResolver:
                         return Exists(Doi(v["data"]["value"]))
 
                 # No URLs found for this DOI, so we treat it as DoesNotExist
-                return DoesNotExist[Doi](f"{doi} does not point to any URL")
+                return DoesNotExist(Doi, f"{doi} does not point to any URL")
             else:
                 # Some other kind of failure, let's propagate our error up
                 resp.raise_for_status()
@@ -195,8 +195,9 @@ class DataverseResolver:
             file_id = os.path.basename(path)
             pid_maybe = await self.get_dataset_id_from_file_id(installation, file_id)
             if pid_maybe is None:
-                return DoesNotExist[DataverseDataset](
-                    f"No file with id {file_id} found in dataverse installation {installation}"
+                return DoesNotExist(
+                    DataverseDataset,
+                    f"No file with id {file_id} found in dataverse installation {installation}",
                 )
             else:
                 persistent_id = pid_maybe
@@ -207,8 +208,9 @@ class DataverseResolver:
             file_id = qs["persistentId"]
             pid_maybe = await self.get_dataset_id_from_file_id(installation, file_id)
             if pid_maybe is None:
-                return DoesNotExist[DataverseDataset](
-                    f"No file with id {file_id} found in dataverse installation {installation}"
+                return DoesNotExist(
+                    DataverseDataset,
+                    f"No file with id {file_id} found in dataverse installation {installation}",
                 )
             else:
                 persistent_id = pid_maybe
@@ -233,8 +235,9 @@ class DataverseResolver:
                 )
                 if pid_maybe is None:
                     # This is not a file either, so this citation doesn't exist
-                    return DoesNotExist[DataverseDataset](
-                        f"{persistent_id} is neither a file nor a dataset in {installation}"
+                    return DoesNotExist(
+                        DataverseDataset,
+                        f"{persistent_id} is neither a file nor a dataset in {installation}",
                     )
                 else:
                     persistent_id = pid_maybe
@@ -306,8 +309,8 @@ class ZenodoResolver:
                 resp = await session.head(url)
 
             if resp.status == 404:
-                return DoesNotExist[ZenodoDataset](
-                    f"{url} is not a valid Zenodo DOI URL"
+                return DoesNotExist(
+                    ZenodoDataset, f"{url} is not a valid Zenodo DOI URL"
                 )
             redirect_location = resp.headers["Location"]
 
@@ -397,8 +400,9 @@ class ImmutableFigshareResolver:
             resp = await session.get(api_url)
 
         if resp.status == 404:
-            return DoesNotExist[ImmutableFigshareDataset](
-                f"Article ID {question.articleId} not found on figshare installation {question.installation.url}"
+            return DoesNotExist(
+                ImmutableFigshareDataset,
+                f"Article ID {question.articleId} not found on figshare installation {question.installation.url}",
             )
         elif resp.status == 200:
             data = await resp.json()

--- a/src/repoproviders/resolvers/doi.py
+++ b/src/repoproviders/resolvers/doi.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 import aiohttp
 from yarl import URL
 
-from .base import NotFound
+from .base import DoesNotExist, Exists, MaybeExists
 
 
 @dataclass(frozen=True)
@@ -67,7 +67,7 @@ class DoiResolver:
     A *handle* resolver, called a Doi resolver because that's the most common handle
     """
 
-    async def resolve(self, question: URL) -> Doi | NotFound[Doi] | None:
+    async def resolve(self, question: URL) -> Exists[Doi] | DoesNotExist[Doi] | None:
         # Check if this is a valid doi or handle
         if question.scheme in ("doi", "hdl"):
             doi = question.path
@@ -97,17 +97,17 @@ class DoiResolver:
 
             if resp.status == 404:
                 # This is a validly *formatted* DOI, but it's not actually a dOI
-                return NotFound[Doi](f"{doi} is not a registered DOI or handle")
+                return DoesNotExist[Doi](f"{doi} is not a registered DOI or handle")
             elif resp.status == 200:
                 data = await resp.json()
 
                 # Pick the first URL we find from the doi response
                 for v in data["values"]:
                     if v["type"] == "URL":
-                        return Doi(v["data"]["value"])
+                        return Exists(Doi(v["data"]["value"]))
 
-                # No URLs found for this DOI, so we treat it as NotFound
-                return NotFound[Doi](f"{doi} does not point to any URL")
+                # No URLs found for this DOI, so we treat it as DoesNotExist
+                return DoesNotExist[Doi](f"{doi} does not point to any URL")
             else:
                 # Some other kind of failure, let's propagate our error up
                 resp.raise_for_status()
@@ -158,7 +158,7 @@ class DataverseResolver:
 
     async def resolve(
         self, question: URL | Doi
-    ) -> DataverseDataset | NotFound[DataverseDataset] | None:
+    ) -> Exists[DataverseDataset] | DoesNotExist[DataverseDataset] | None:
         if isinstance(question, URL):
             url = question
         elif isinstance(question, Doi):
@@ -195,7 +195,7 @@ class DataverseResolver:
             file_id = os.path.basename(path)
             pid_maybe = await self.get_dataset_id_from_file_id(installation, file_id)
             if pid_maybe is None:
-                return NotFound[DataverseDataset](
+                return DoesNotExist[DataverseDataset](
                     f"No file with id {file_id} found in dataverse installation {installation}"
                 )
             else:
@@ -207,7 +207,7 @@ class DataverseResolver:
             file_id = qs["persistentId"]
             pid_maybe = await self.get_dataset_id_from_file_id(installation, file_id)
             if pid_maybe is None:
-                return NotFound[DataverseDataset](
+                return DoesNotExist[DataverseDataset](
                     f"No file with id {file_id} found in dataverse installation {installation}"
                 )
             else:
@@ -233,17 +233,21 @@ class DataverseResolver:
                 )
                 if pid_maybe is None:
                     # This is not a file either, so this citation doesn't exist
-                    return NotFound[DataverseDataset](
+                    return DoesNotExist[DataverseDataset](
                         f"{persistent_id} is neither a file nor a dataset in {installation}"
                     )
                 else:
                     persistent_id = pid_maybe
+            elif resp.status == 200:
+                # This *is* a dataset, we just verified it with this query
+                verified_dataset = True
             else:
                 # Any other errors should propagate
                 resp.raise_for_status()
 
-        # If we are here, it means the persistent_id is a dataset id, and we don't need to do anything else!
-        return DataverseDataset(installation, persistent_id)
+                return None
+
+        return Exists(DataverseDataset(installation, persistent_id))
 
 
 class ZenodoResolver:
@@ -261,7 +265,7 @@ class ZenodoResolver:
 
     async def resolve(
         self, question: URL | Doi
-    ) -> ZenodoDataset | NotFound[ZenodoDataset] | None:
+    ) -> MaybeExists[ZenodoDataset] | DoesNotExist[ZenodoDataset] | None:
         if isinstance(question, URL):
             url = question
         elif isinstance(question, Doi):
@@ -302,14 +306,16 @@ class ZenodoResolver:
                 resp = await session.head(url)
 
             if resp.status == 404:
-                return NotFound[ZenodoDataset](f"{url} is not a valid Zenodo DOI URL")
+                return DoesNotExist[ZenodoDataset](
+                    f"{url} is not a valid Zenodo DOI URL"
+                )
             redirect_location = resp.headers["Location"]
 
             return await self.resolve(URL(redirect_location))
         else:
             # URL is /record or /records
             # Record ID is the last part of the URL path
-            return ZenodoDataset(installation, url.name)
+            return MaybeExists(ZenodoDataset(installation, url.name))
 
 
 class FigshareResolver:
@@ -322,7 +328,7 @@ class FigshareResolver:
             )
         ]
 
-    async def resolve(self, question: URL | Doi) -> FigshareDataset | None:
+    async def resolve(self, question: URL | Doi) -> MaybeExists[FigshareDataset] | None:
         if isinstance(question, URL):
             url = question
         elif isinstance(question, Doi):
@@ -354,9 +360,11 @@ class FigshareResolver:
         # If not, treat it as article ID only
         parts = url.path.split("/")
         if parts[-1].isdigit() and parts[-2].isdigit():
-            return FigshareDataset(installation, int(parts[-2]), int(parts[-1]))
+            return MaybeExists(
+                FigshareDataset(installation, int(parts[-2]), int(parts[-1]))
+            )
         elif parts[-1].isdigit():
-            return FigshareDataset(installation, int(parts[-1]), None)
+            return MaybeExists(FigshareDataset(installation, int(parts[-1]), None))
         else:
             return None
 
@@ -364,11 +372,18 @@ class FigshareResolver:
 class ImmutableFigshareResolver:
     async def resolve(
         self, question: FigshareDataset
-    ) -> ImmutableFigshareDataset | NotFound[ImmutableFigshareDataset] | None:
+    ) -> (
+        Exists[ImmutableFigshareDataset]
+        | MaybeExists[ImmutableFigshareDataset]
+        | DoesNotExist[ImmutableFigshareDataset]
+        | None
+    ):
         if question.version is not None:
             # Version already specified, just return
-            return ImmutableFigshareDataset(
-                question.installation, question.articleId, question.version
+            return MaybeExists(
+                ImmutableFigshareDataset(
+                    question.installation, question.articleId, question.version
+                )
             )
 
         api_url = (
@@ -382,13 +397,15 @@ class ImmutableFigshareResolver:
             resp = await session.get(api_url)
 
         if resp.status == 404:
-            return NotFound[ImmutableFigshareDataset](
+            return DoesNotExist[ImmutableFigshareDataset](
                 f"Article ID {question.articleId} not found on figshare installation {question.installation.url}"
             )
         elif resp.status == 200:
             data = await resp.json()
-            return ImmutableFigshareDataset(
-                question.installation, question.articleId, data[-1]["version"]
+            return Exists(
+                ImmutableFigshareDataset(
+                    question.installation, question.articleId, data[-1]["version"]
+                )
             )
         else:
             # All other status codes should raise an error

--- a/src/repoproviders/resolvers/git.py
+++ b/src/repoproviders/resolvers/git.py
@@ -80,8 +80,8 @@ class ImmutableGitResolver:
             # `git` may follow redirects here, so the repo we pass may not always be the repo we
             # get back. So we loosely check for a 'not found' message.
             if re.search(r"fatal: repository '(.+)' not found", stderr, re.MULTILINE):
-                return DoesNotExist[ImmutableGit](
-                    f"Could not access git repository at {question.repo}"
+                return DoesNotExist(
+                    ImmutableGit, f"Could not access git repository at {question.repo}"
                 )
 
             # If it's another error, let's raise it directly
@@ -98,8 +98,8 @@ class ImmutableGitResolver:
                 resolved_ref = question.ref
                 return MaybeExists(ImmutableGit(question.repo, resolved_ref))
             else:
-                return DoesNotExist[ImmutableGit](
-                    f"No ref {question.ref} found in repo {question.repo}"
+                return DoesNotExist(
+                    ImmutableGit, f"No ref {question.ref} found in repo {question.repo}"
                 )
         else:
             resolved_ref = stdout.split("\t", 1)[0]

--- a/src/repoproviders/resolvers/git.py
+++ b/src/repoproviders/resolvers/git.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 
 from yarl import URL
 
-from .base import NotFound
+from .base import DoesNotExist, Exists, MaybeExists
 
 
 @dataclass(frozen=True)
@@ -32,7 +32,7 @@ class ImmutableGit:
 
 
 class GitHubResolver:
-    async def resolve(self, question: URL) -> Git | None:
+    async def resolve(self, question: URL) -> MaybeExists[Git] | None:
         # git+<scheme> urls are handled by a different resolver
         if question.scheme not in ("http", "https") or (
             question.host != "github.com" and question.host != "www.github.com"
@@ -45,14 +45,16 @@ class GitHubResolver:
         if len(parts) == 2:
             # Handle <user|org>/<repo>
             # Reconstruct the URL so we normalize any
-            return Git(
-                repo=str(question.with_path(f"{parts[0]}/{parts[1]}")), ref="HEAD"
+            return MaybeExists(
+                Git(repo=str(question.with_path(f"{parts[0]}/{parts[1]}")), ref="HEAD")
             )
         elif len(parts) >= 4 and parts[2] in ("tree", "blob"):
             # Handle <user|org>/<repo>/<tree|blob>/<ref>(/<possible-path>)
             # Note: We ignore any paths specified here, as we only care about the repo
-            return Git(
-                repo=str(question.with_path(f"{parts[0]}/{parts[1]}")), ref=parts[3]
+            return MaybeExists(
+                Git(
+                    repo=str(question.with_path(f"{parts[0]}/{parts[1]}")), ref=parts[3]
+                )
             )
         else:
             # This is not actually a valid GitHub URL we support
@@ -62,7 +64,12 @@ class GitHubResolver:
 class ImmutableGitResolver:
     async def resolve(
         self, question: Git
-    ) -> ImmutableGit | NotFound[ImmutableGit] | None:
+    ) -> (
+        Exists[ImmutableGit]
+        | MaybeExists[ImmutableGit]
+        | DoesNotExist[ImmutableGit]
+        | None
+    ):
         command = ["git", "ls-remote", "--", question.repo, question.ref]
         proc = await asyncio.create_subprocess_exec(
             *command, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
@@ -73,7 +80,7 @@ class ImmutableGitResolver:
             # `git` may follow redirects here, so the repo we pass may not always be the repo we
             # get back. So we loosely check for a 'not found' message.
             if re.search(r"fatal: repository '(.+)' not found", stderr, re.MULTILINE):
-                return NotFound[ImmutableGit](
+                return DoesNotExist[ImmutableGit](
                     f"Could not access git repository at {question.repo}"
                 )
 
@@ -89,14 +96,15 @@ class ImmutableGitResolver:
             # we can't guarantee that the repo itself exists
             if re.match(r"[0-9a-f]{40}", question.ref):
                 resolved_ref = question.ref
+                return MaybeExists(ImmutableGit(question.repo, resolved_ref))
             else:
-                return NotFound[ImmutableGit](
+                return DoesNotExist[ImmutableGit](
                     f"No ref {question.ref} found in repo {question.repo}"
                 )
         else:
             resolved_ref = stdout.split("\t", 1)[0]
 
-        return ImmutableGit(question.repo, resolved_ref)
+            return Exists(ImmutableGit(question.repo, resolved_ref))
 
 
 class GitUrlResolver:
@@ -106,7 +114,7 @@ class GitUrlResolver:
     URL structure is inspired by what `pip` supports: https://pip.pypa.io/en/stable/topics/vcs-support/#git
     """
 
-    async def resolve(self, question: URL) -> Git | None:
+    async def resolve(self, question: URL) -> MaybeExists[Git] | None:
         # List of supported protocols is from https://pip.pypa.io/en/stable/topics/vcs-support/#git
         if question.scheme not in (
             "git+https",
@@ -127,4 +135,4 @@ class GitUrlResolver:
         else:
             ref = "HEAD"
 
-        return Git(str(repo), ref)
+        return MaybeExists(Git(str(repo), ref))

--- a/src/repoproviders/resolvers/resolver.py
+++ b/src/repoproviders/resolvers/resolver.py
@@ -60,7 +60,7 @@ async def resolve(
             if resp is not None:
                 # We found an answer!
                 answers.append(resp)
-                # Break after we find an answer in each round
+                # Break out of the for after we find an answer in each round
                 break
 
         if recursive:

--- a/tests/fetchers/test_dataverse.py
+++ b/tests/fetchers/test_dataverse.py
@@ -6,6 +6,7 @@ import pytest
 
 from repoproviders.fetchers import fetch
 from repoproviders.resolvers import resolve
+from repoproviders.resolvers.base import Exists
 
 
 @pytest.mark.parametrize(
@@ -70,8 +71,9 @@ async def test_fetch(questions: list[str], md5tree: dict[str, str]):
             answers = await resolve(question, True)
 
             assert answers is not None
+            assert isinstance(answers[-1], Exists)
 
-            await fetch(answers[-1], output_dir)
+            await fetch(answers[-1].repo, output_dir)
 
             # Verify md5 sum of the files we expect to find
             # We are using md5 instead of something more secure because that is what

--- a/tests/resolvers/test_dataverse.py
+++ b/tests/resolvers/test_dataverse.py
@@ -56,27 +56,31 @@ from repoproviders.resolvers.doi import DataverseDataset, DataverseResolver
         # Asking for datasets that don't exist should return DoesNotExist
         (
             "https://dataverse.harvard.edu/citation?persistentId=doi:10.7910/not-found",
-            DoesNotExist[DataverseDataset](
-                "doi:10.7910/not-found is neither a file nor a dataset in https://dataverse.harvard.edu"
+            DoesNotExist(
+                DataverseDataset,
+                "doi:10.7910/not-found is neither a file nor a dataset in https://dataverse.harvard.edu",
             ),
         ),
         (
             "https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/not-found",
-            DoesNotExist[DataverseDataset](
-                "doi:10.7910/not-found is neither a file nor a dataset in https://dataverse.harvard.edu"
+            DoesNotExist(
+                DataverseDataset,
+                "doi:10.7910/not-found is neither a file nor a dataset in https://dataverse.harvard.edu",
             ),
         ),
         (
             "https://dataverse.harvard.edu/api/access/datafile/0",
-            DoesNotExist[DataverseDataset](
-                "No file with id 0 found in dataverse installation https://dataverse.harvard.edu"
+            DoesNotExist(
+                DataverseDataset,
+                "No file with id 0 found in dataverse installation https://dataverse.harvard.edu",
             ),
         ),
         ("https://dataverse.harvard.edu/blaaaah", None),
         (
             "https://dataverse.harvard.edu/file.xhtml?persistentId=doi:10.7910/not-found",
-            DoesNotExist[DataverseDataset](
-                "No file with id doi:10.7910/not-found found in dataverse installation https://dataverse.harvard.edu"
+            DoesNotExist(
+                DataverseDataset,
+                "No file with id doi:10.7910/not-found found in dataverse installation https://dataverse.harvard.edu",
             ),
         ),
     ),

--- a/tests/resolvers/test_dataverse.py
+++ b/tests/resolvers/test_dataverse.py
@@ -1,7 +1,7 @@
 import pytest
 from yarl import URL
 
-from repoproviders.resolvers.base import NotFound
+from repoproviders.resolvers.base import DoesNotExist, Exists
 from repoproviders.resolvers.doi import DataverseDataset, DataverseResolver
 
 
@@ -14,58 +14,68 @@ from repoproviders.resolvers.doi import DataverseDataset, DataverseResolver
         # A dataset citation returns the dataset correctly
         (
             "https://dataverse.harvard.edu/citation?persistentId=doi:10.7910/DVN/TJCLKP",
-            DataverseDataset(
-                URL("https://dataverse.harvard.edu"), "doi:10.7910/DVN/TJCLKP"
+            Exists(
+                DataverseDataset(
+                    URL("https://dataverse.harvard.edu"), "doi:10.7910/DVN/TJCLKP"
+                )
             ),
         ),
         (
             "https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/TJCLKP",
-            DataverseDataset(
-                URL("https://dataverse.harvard.edu"), "doi:10.7910/DVN/TJCLKP"
+            Exists(
+                DataverseDataset(
+                    URL("https://dataverse.harvard.edu"), "doi:10.7910/DVN/TJCLKP"
+                )
             ),
         ),
         # Asking for specific files should give us the whole dataset they are a part of
         (
             "https://dataverse.harvard.edu/api/access/datafile/3323458",
-            DataverseDataset(
-                URL("https://dataverse.harvard.edu"), "doi:10.7910/DVN/3MJ7IR"
+            Exists(
+                DataverseDataset(
+                    URL("https://dataverse.harvard.edu"), "doi:10.7910/DVN/3MJ7IR"
+                )
             ),
         ),
         (
             "https://dataverse.harvard.edu/citation?persistentId=doi:10.7910/DVN/6ZXAGT/3YRRYJ",
-            DataverseDataset(
-                URL("https://dataverse.harvard.edu"), "doi:10.7910/DVN/6ZXAGT"
+            Exists(
+                DataverseDataset(
+                    URL("https://dataverse.harvard.edu"), "doi:10.7910/DVN/6ZXAGT"
+                )
             ),
         ),
         (
             "https://dataverse.harvard.edu/file.xhtml?persistentId=doi:10.7910/DVN/6ZXAGT/3YRRYJ",
-            DataverseDataset(
-                URL("https://dataverse.harvard.edu"), "doi:10.7910/DVN/6ZXAGT"
+            Exists(
+                DataverseDataset(
+                    URL("https://dataverse.harvard.edu"), "doi:10.7910/DVN/6ZXAGT"
+                )
             ),
         ),
-        # Asking for datasets that don't exist should return NotFound
+        # Asking for datasets that don't exist should return DoesNotExist
         (
             "https://dataverse.harvard.edu/citation?persistentId=doi:10.7910/not-found",
-            NotFound[DataverseDataset](
+            DoesNotExist[DataverseDataset](
                 "doi:10.7910/not-found is neither a file nor a dataset in https://dataverse.harvard.edu"
             ),
         ),
         (
             "https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/not-found",
-            NotFound[DataverseDataset](
+            DoesNotExist[DataverseDataset](
                 "doi:10.7910/not-found is neither a file nor a dataset in https://dataverse.harvard.edu"
             ),
         ),
         (
             "https://dataverse.harvard.edu/api/access/datafile/0",
-            NotFound[DataverseDataset](
+            DoesNotExist[DataverseDataset](
                 "No file with id 0 found in dataverse installation https://dataverse.harvard.edu"
             ),
         ),
         ("https://dataverse.harvard.edu/blaaaah", None),
         (
             "https://dataverse.harvard.edu/file.xhtml?persistentId=doi:10.7910/not-found",
-            NotFound[DataverseDataset](
+            DoesNotExist[DataverseDataset](
                 "No file with id doi:10.7910/not-found found in dataverse installation https://dataverse.harvard.edu"
             ),
         ),

--- a/tests/resolvers/test_doi.py
+++ b/tests/resolvers/test_doi.py
@@ -1,6 +1,7 @@
 import pytest
 from yarl import URL
 
+from repoproviders.resolvers.base import Exists
 from repoproviders.resolvers.doi import Doi, DoiResolver
 
 
@@ -11,20 +12,28 @@ from repoproviders.resolvers.doi import Doi, DoiResolver
         # doi schema'd URI
         (
             "doi:10.7910/DVN/6ZXAGT/3YRRYJ",
-            Doi(
-                "https://dataverse.harvard.edu/file.xhtml?persistentId=doi:10.7910/DVN/6ZXAGT/3YRRYJ"
+            Exists(
+                Doi(
+                    "https://dataverse.harvard.edu/file.xhtml?persistentId=doi:10.7910/DVN/6ZXAGT/3YRRYJ"
+                )
             ),
         ),
         # handle schema'd URI
         (
             "hdl:11529/10016",
-            Doi("https://data.cimmyt.org/dataset.xhtml?persistentId=hdl:11529/10016"),
+            Exists(
+                Doi(
+                    "https://data.cimmyt.org/dataset.xhtml?persistentId=hdl:11529/10016"
+                )
+            ),
         ),
         # For convenience, we do accept DOIs without a scheme
         (
             "10.7910/DVN/6ZXAGT/3YRRYJ",
-            Doi(
-                "https://dataverse.harvard.edu/file.xhtml?persistentId=doi:10.7910/DVN/6ZXAGT/3YRRYJ"
+            Exists(
+                Doi(
+                    "https://dataverse.harvard.edu/file.xhtml?persistentId=doi:10.7910/DVN/6ZXAGT/3YRRYJ"
+                )
             ),
         ),
         # But not handles without a scheme
@@ -32,20 +41,26 @@ from repoproviders.resolvers.doi import Doi, DoiResolver
         # Three DOI resolution URLs
         (
             "https://doi.org/10.7910/DVN/6ZXAGT/3YRRYJ",
-            Doi(
-                "https://dataverse.harvard.edu/file.xhtml?persistentId=doi:10.7910/DVN/6ZXAGT/3YRRYJ"
+            Exists(
+                Doi(
+                    "https://dataverse.harvard.edu/file.xhtml?persistentId=doi:10.7910/DVN/6ZXAGT/3YRRYJ"
+                )
             ),
         ),
         (
             "https://www.doi.org/10.7910/DVN/6ZXAGT/3YRRYJ",
-            Doi(
-                "https://dataverse.harvard.edu/file.xhtml?persistentId=doi:10.7910/DVN/6ZXAGT/3YRRYJ"
+            Exists(
+                Doi(
+                    "https://dataverse.harvard.edu/file.xhtml?persistentId=doi:10.7910/DVN/6ZXAGT/3YRRYJ"
+                )
             ),
         ),
         (
             "https://hdl.handle.net/10.7910/DVN/6ZXAGT/3YRRYJ",
-            Doi(
-                "https://dataverse.harvard.edu/file.xhtml?persistentId=doi:10.7910/DVN/6ZXAGT/3YRRYJ"
+            Exists(
+                Doi(
+                    "https://dataverse.harvard.edu/file.xhtml?persistentId=doi:10.7910/DVN/6ZXAGT/3YRRYJ"
+                )
             ),
         ),
     ),

--- a/tests/resolvers/test_figshare.py
+++ b/tests/resolvers/test_figshare.py
@@ -133,8 +133,9 @@ async def test_figshare(url, expected):
                 97827778384384634634634863463434343,
                 None,
             ),
-            DoesNotExist[ImmutableFigshareDataset](
-                "Article ID 97827778384384634634634863463434343 not found on figshare installation https://figshare.com/"
+            DoesNotExist(
+                ImmutableFigshareDataset,
+                "Article ID 97827778384384634634634863463434343 not found on figshare installation https://figshare.com/",
             ),
         ),
     ),

--- a/tests/resolvers/test_figshare.py
+++ b/tests/resolvers/test_figshare.py
@@ -1,7 +1,7 @@
 import pytest
 from yarl import URL
 
-from repoproviders.resolvers.base import NotFound
+from repoproviders.resolvers.base import DoesNotExist, Exists, MaybeExists
 from repoproviders.resolvers.doi import (
     FigshareDataset,
     FigshareInstallation,
@@ -25,43 +25,55 @@ from repoproviders.resolvers.doi import (
         # Some old school URLs
         (
             "https://figshare.com/articles/title/9782777",
-            FigshareDataset(
-                FigshareInstallation(
-                    URL("https://figshare.com/"), URL("https://api.figshare.com/v2/")
-                ),
-                9782777,
-                None,
+            MaybeExists(
+                FigshareDataset(
+                    FigshareInstallation(
+                        URL("https://figshare.com/"),
+                        URL("https://api.figshare.com/v2/"),
+                    ),
+                    9782777,
+                    None,
+                )
             ),
         ),
         (
             "https://figshare.com/articles/title/9782777/2",
-            FigshareDataset(
-                FigshareInstallation(
-                    URL("https://figshare.com/"), URL("https://api.figshare.com/v2/")
-                ),
-                9782777,
-                2,
+            MaybeExists(
+                FigshareDataset(
+                    FigshareInstallation(
+                        URL("https://figshare.com/"),
+                        URL("https://api.figshare.com/v2/"),
+                    ),
+                    9782777,
+                    2,
+                )
             ),
         ),
         # New style URLs
         (
             "https://figshare.com/articles/code/Binder-ready_openSenseMap_Analysis/9782777",
-            FigshareDataset(
-                FigshareInstallation(
-                    URL("https://figshare.com/"), URL("https://api.figshare.com/v2/")
-                ),
-                9782777,
-                None,
+            MaybeExists(
+                FigshareDataset(
+                    FigshareInstallation(
+                        URL("https://figshare.com/"),
+                        URL("https://api.figshare.com/v2/"),
+                    ),
+                    9782777,
+                    None,
+                )
             ),
         ),
         (
             "https://figshare.com/articles/code/Binder-ready_openSenseMap_Analysis/9782777/3",
-            FigshareDataset(
-                FigshareInstallation(
-                    URL("https://figshare.com/"), URL("https://api.figshare.com/v2/")
-                ),
-                9782777,
-                3,
+            MaybeExists(
+                FigshareDataset(
+                    FigshareInstallation(
+                        URL("https://figshare.com/"),
+                        URL("https://api.figshare.com/v2/"),
+                    ),
+                    9782777,
+                    3,
+                )
             ),
         ),
     ),
@@ -82,12 +94,15 @@ async def test_figshare(url, expected):
                 9782777,
                 None,
             ),
-            ImmutableFigshareDataset(
-                FigshareInstallation(
-                    URL("https://figshare.com/"), URL("https://api.figshare.com/v2/")
-                ),
-                9782777,
-                3,
+            Exists(
+                ImmutableFigshareDataset(
+                    FigshareInstallation(
+                        URL("https://figshare.com/"),
+                        URL("https://api.figshare.com/v2/"),
+                    ),
+                    9782777,
+                    3,
+                )
             ),
         ),
         (
@@ -98,12 +113,15 @@ async def test_figshare(url, expected):
                 9782777,
                 2,
             ),
-            ImmutableFigshareDataset(
-                FigshareInstallation(
-                    URL("https://figshare.com/"), URL("https://api.figshare.com/v2/")
-                ),
-                9782777,
-                2,
+            MaybeExists(
+                ImmutableFigshareDataset(
+                    FigshareInstallation(
+                        URL("https://figshare.com/"),
+                        URL("https://api.figshare.com/v2/"),
+                    ),
+                    9782777,
+                    2,
+                )
             ),
         ),
         # Non existent things
@@ -115,7 +133,7 @@ async def test_figshare(url, expected):
                 97827778384384634634634863463434343,
                 None,
             ),
-            NotFound[ImmutableFigshareDataset](
+            DoesNotExist[ImmutableFigshareDataset](
                 "Article ID 97827778384384634634634863463434343 not found on figshare installation https://figshare.com/"
             ),
         ),

--- a/tests/resolvers/test_github.py
+++ b/tests/resolvers/test_github.py
@@ -1,6 +1,7 @@
 import pytest
 from yarl import URL
 
+from repoproviders.resolvers.base import MaybeExists
 from repoproviders.resolvers.git import Git, GitHubResolver
 
 
@@ -19,34 +20,47 @@ from repoproviders.resolvers.git import Git, GitHubResolver
         # Simple github repo URL
         (
             "https://github.com/pyOpenSci/pyos-package-template",
-            Git("https://github.com/pyOpenSci/pyos-package-template", "HEAD"),
+            MaybeExists(
+                Git("https://github.com/pyOpenSci/pyos-package-template", "HEAD")
+            ),
         ),
         # Trailing slash normalized?
         (
             "https://github.com/pyOpenSci/pyos-package-template/",
-            Git("https://github.com/pyOpenSci/pyos-package-template", "HEAD"),
+            MaybeExists(
+                Git("https://github.com/pyOpenSci/pyos-package-template", "HEAD")
+            ),
         ),
         # blobs and tree
         (
             "https://github.com/pyOpenSci/pyos-package-template/tree/main/includes/licenses",
-            Git("https://github.com/pyOpenSci/pyos-package-template", "main"),
+            MaybeExists(
+                Git("https://github.com/pyOpenSci/pyos-package-template", "main")
+            ),
         ),
         (
             "https://github.com/pyOpenSci/pyos-package-template/tree/original-cookie/docs",
-            Git(
-                "https://github.com/pyOpenSci/pyos-package-template", "original-cookie"
+            MaybeExists(
+                Git(
+                    "https://github.com/pyOpenSci/pyos-package-template",
+                    "original-cookie",
+                )
             ),
         ),
         (
             "https://github.com/pyOpenSci/pyos-package-template/blob/b912433bfae541972c83529359f4181ef0fe9b67/README.md",
-            Git(
-                "https://github.com/pyOpenSci/pyos-package-template",
-                ref="b912433bfae541972c83529359f4181ef0fe9b67",
+            MaybeExists(
+                Git(
+                    "https://github.com/pyOpenSci/pyos-package-template",
+                    ref="b912433bfae541972c83529359f4181ef0fe9b67",
+                )
             ),
         ),
         (
             "https://github.com/yuvipanda/does-not-exist-e43",
-            Git(repo="https://github.com/yuvipanda/does-not-exist-e43", ref="HEAD"),
+            MaybeExists(
+                Git(repo="https://github.com/yuvipanda/does-not-exist-e43", ref="HEAD")
+            ),
         ),
     ),
 )

--- a/tests/resolvers/test_giturl.py
+++ b/tests/resolvers/test_giturl.py
@@ -1,6 +1,7 @@
 import pytest
 from yarl import URL
 
+from repoproviders.resolvers.base import MaybeExists
 from repoproviders.resolvers.git import Git, GitUrlResolver
 
 
@@ -12,26 +13,41 @@ from repoproviders.resolvers.git import Git, GitUrlResolver
         # Not a real repo, but looks like one
         (
             "git+https://example.com/something",
-            Git("https://example.com/something", "HEAD"),
+            MaybeExists(Git("https://example.com/something", "HEAD")),
         ),
-        ("git+ssh://example.com/something", Git("ssh://example.com/something", "HEAD")),
+        (
+            "git+ssh://example.com/something",
+            MaybeExists(Git("ssh://example.com/something", "HEAD")),
+        ),
         # With a ref
         (
             "git+https://github.com/yuvipanda/requirements@main",
-            Git("https://github.com/yuvipanda/requirements", "main"),
+            MaybeExists(Git("https://github.com/yuvipanda/requirements", "main")),
         ),
         # With edge case refs
         (
             "git+https://github.com/yuvipanda/requirements@tag/something",
-            Git("https://github.com/yuvipanda/requirements", "tag/something"),
+            MaybeExists(
+                Git("https://github.com/yuvipanda/requirements", "tag/something")
+            ),
         ),
         (
             "git+https://yuvipanda@github.com/yuvipanda/requirements@tag/something",
-            Git("https://yuvipanda@github.com/yuvipanda/requirements", "tag/something"),
+            MaybeExists(
+                Git(
+                    "https://yuvipanda@github.com/yuvipanda/requirements",
+                    "tag/something",
+                )
+            ),
         ),
         (
             "git+https://yuvipanda@github.com/yuvipanda/requirements@tag@something",
-            Git("https://yuvipanda@github.com/yuvipanda/requirements", "tag@something"),
+            MaybeExists(
+                Git(
+                    "https://yuvipanda@github.com/yuvipanda/requirements",
+                    "tag@something",
+                )
+            ),
         ),
     ),
 )

--- a/tests/resolvers/test_immutablegit.py
+++ b/tests/resolvers/test_immutablegit.py
@@ -10,8 +10,9 @@ from repoproviders.resolvers.git import Git, ImmutableGit, ImmutableGitResolver
         # Random URL, not a git repo
         (
             Git("https://example.com/something", "HEAD"),
-            DoesNotExist[ImmutableGit](
-                "Could not access git repository at https://example.com/something"
+            DoesNotExist(
+                ImmutableGit,
+                "Could not access git repository at https://example.com/something",
             ),
         ),
         # Resolve a tag
@@ -40,8 +41,9 @@ from repoproviders.resolvers.git import Git, ImmutableGit, ImmutableGitResolver
         # Repo doesn't exist
         (
             Git(repo="https://github.com/yuvipanda/does-not-exist-e43", ref="HEAD"),
-            DoesNotExist[ImmutableGit](
-                "Could not access git repository at https://github.com/yuvipanda/does-not-exist-e43"
+            DoesNotExist(
+                ImmutableGit,
+                "Could not access git repository at https://github.com/yuvipanda/does-not-exist-e43",
             ),
         ),
         # Ref doesn't exist
@@ -49,8 +51,9 @@ from repoproviders.resolvers.git import Git, ImmutableGit, ImmutableGitResolver
             Git(
                 "https://github.com/jupyterhub/zero-to-jupyterhub-k8s", "does-not-exist"
             ),
-            DoesNotExist[ImmutableGit](
-                "No ref does-not-exist found in repo https://github.com/jupyterhub/zero-to-jupyterhub-k8s"
+            DoesNotExist(
+                ImmutableGit,
+                "No ref does-not-exist found in repo https://github.com/jupyterhub/zero-to-jupyterhub-k8s",
             ),
         ),
     ),

--- a/tests/resolvers/test_immutablegit.py
+++ b/tests/resolvers/test_immutablegit.py
@@ -1,6 +1,6 @@
 import pytest
 
-from repoproviders.resolvers.base import NotFound
+from repoproviders.resolvers.base import DoesNotExist, Exists, MaybeExists
 from repoproviders.resolvers.git import Git, ImmutableGit, ImmutableGitResolver
 
 
@@ -10,16 +10,18 @@ from repoproviders.resolvers.git import Git, ImmutableGit, ImmutableGitResolver
         # Random URL, not a git repo
         (
             Git("https://example.com/something", "HEAD"),
-            NotFound[ImmutableGit](
+            DoesNotExist[ImmutableGit](
                 "Could not access git repository at https://example.com/something"
             ),
         ),
         # Resolve a tag
         (
             Git("https://github.com/jupyterhub/zero-to-jupyterhub-k8s", "0.8.0"),
-            ImmutableGit(
-                "https://github.com/jupyterhub/zero-to-jupyterhub-k8s",
-                "ada2170a2181ae1760d85eab74e5264d0c6bb67f",
+            Exists(
+                ImmutableGit(
+                    "https://github.com/jupyterhub/zero-to-jupyterhub-k8s",
+                    "ada2170a2181ae1760d85eab74e5264d0c6bb67f",
+                )
             ),
         ),
         # Resolve a commit we know exists, although this isn't verified
@@ -28,15 +30,17 @@ from repoproviders.resolvers.git import Git, ImmutableGit, ImmutableGitResolver
                 "https://github.com/jupyterhub/zero-to-jupyterhub-k8s",
                 "f7f3ff6d1bf708bdc12e5f10e18b2a90a4795603",
             ),
-            ImmutableGit(
-                "https://github.com/jupyterhub/zero-to-jupyterhub-k8s",
-                "f7f3ff6d1bf708bdc12e5f10e18b2a90a4795603",
+            MaybeExists(
+                ImmutableGit(
+                    "https://github.com/jupyterhub/zero-to-jupyterhub-k8s",
+                    "f7f3ff6d1bf708bdc12e5f10e18b2a90a4795603",
+                )
             ),
         ),
         # Repo doesn't exist
         (
             Git(repo="https://github.com/yuvipanda/does-not-exist-e43", ref="HEAD"),
-            NotFound[ImmutableGit](
+            DoesNotExist[ImmutableGit](
                 "Could not access git repository at https://github.com/yuvipanda/does-not-exist-e43"
             ),
         ),
@@ -45,7 +49,7 @@ from repoproviders.resolvers.git import Git, ImmutableGit, ImmutableGitResolver
             Git(
                 "https://github.com/jupyterhub/zero-to-jupyterhub-k8s", "does-not-exist"
             ),
-            NotFound[ImmutableGit](
+            DoesNotExist[ImmutableGit](
                 "No ref does-not-exist found in repo https://github.com/jupyterhub/zero-to-jupyterhub-k8s"
             ),
         ),
@@ -65,7 +69,7 @@ async def test_immutable_git_HEAD():
     ig = ImmutableGitResolver()
     assert (
         await ig.resolve(
-            Git("https://github.com/jupyterhub/zero-to-jupyterhub-k8s", "main")
+            Git("https://github.com/jupyterhub/zero-to-jupyterhub-k8s", "HEAD")
         )
     ) == (
         await ig.resolve(

--- a/tests/resolvers/test_resolve.py
+++ b/tests/resolvers/test_resolve.py
@@ -79,8 +79,9 @@ from repoproviders.resolvers.git import Git, ImmutableGit
         (
             Git("https://example.com/something", "HEAD"),
             [
-                DoesNotExist[ImmutableGit](
-                    "Could not access git repository at https://example.com/something"
+                DoesNotExist(
+                    ImmutableGit,
+                    "Could not access git repository at https://example.com/something",
                 )
             ],
         ),
@@ -116,8 +117,9 @@ from repoproviders.resolvers.git import Git, ImmutableGit
                 "https://github.com/jupyterhub/zero-to-jupyterhub-k8s", "does-not-exist"
             ),
             [
-                DoesNotExist[ImmutableGit](
-                    "No ref does-not-exist found in repo https://github.com/jupyterhub/zero-to-jupyterhub-k8s"
+                DoesNotExist(
+                    ImmutableGit,
+                    "No ref does-not-exist found in repo https://github.com/jupyterhub/zero-to-jupyterhub-k8s",
                 )
             ],
         ),

--- a/tests/resolvers/test_resolve.py
+++ b/tests/resolvers/test_resolve.py
@@ -2,7 +2,7 @@ import pytest
 from yarl import URL
 
 from repoproviders.resolvers import resolve
-from repoproviders.resolvers.base import NotFound
+from repoproviders.resolvers.base import DoesNotExist, Exists, MaybeExists
 from repoproviders.resolvers.doi import (
     DataverseDataset,
     Doi,
@@ -29,33 +29,49 @@ from repoproviders.resolvers.git import Git, ImmutableGit
         # Simple github repo URL
         (
             "https://github.com/pyOpenSci/pyos-package-template",
-            [Git("https://github.com/pyOpenSci/pyos-package-template", "HEAD")],
+            [
+                MaybeExists(
+                    Git("https://github.com/pyOpenSci/pyos-package-template", "HEAD")
+                )
+            ],
         ),
         # Trailing slash normalized?
         (
             "https://github.com/pyOpenSci/pyos-package-template/",
-            [Git("https://github.com/pyOpenSci/pyos-package-template", "HEAD")],
+            [
+                MaybeExists(
+                    Git("https://github.com/pyOpenSci/pyos-package-template", "HEAD")
+                )
+            ],
         ),
         # blobs and tree
         (
             "https://github.com/pyOpenSci/pyos-package-template/tree/main/includes/licenses",
-            [Git("https://github.com/pyOpenSci/pyos-package-template", "main")],
+            [
+                MaybeExists(
+                    Git("https://github.com/pyOpenSci/pyos-package-template", "main")
+                )
+            ],
         ),
         (
             "https://github.com/pyOpenSci/pyos-package-template/tree/original-cookie/docs",
             [
-                Git(
-                    "https://github.com/pyOpenSci/pyos-package-template",
-                    "original-cookie",
+                MaybeExists(
+                    Git(
+                        "https://github.com/pyOpenSci/pyos-package-template",
+                        "original-cookie",
+                    )
                 )
             ],
         ),
         (
             "https://github.com/pyOpenSci/pyos-package-template/blob/b912433bfae541972c83529359f4181ef0fe9b67/README.md",
             [
-                Git(
-                    "https://github.com/pyOpenSci/pyos-package-template",
-                    ref="b912433bfae541972c83529359f4181ef0fe9b67",
+                MaybeExists(
+                    Git(
+                        "https://github.com/pyOpenSci/pyos-package-template",
+                        ref="b912433bfae541972c83529359f4181ef0fe9b67",
+                    )
                 )
             ],
         ),
@@ -63,7 +79,7 @@ from repoproviders.resolvers.git import Git, ImmutableGit
         (
             Git("https://example.com/something", "HEAD"),
             [
-                NotFound[ImmutableGit](
+                DoesNotExist[ImmutableGit](
                     "Could not access git repository at https://example.com/something"
                 )
             ],
@@ -72,9 +88,11 @@ from repoproviders.resolvers.git import Git, ImmutableGit
         (
             Git("https://github.com/jupyterhub/zero-to-jupyterhub-k8s", "0.8.0"),
             [
-                ImmutableGit(
-                    "https://github.com/jupyterhub/zero-to-jupyterhub-k8s",
-                    "ada2170a2181ae1760d85eab74e5264d0c6bb67f",
+                Exists(
+                    ImmutableGit(
+                        "https://github.com/jupyterhub/zero-to-jupyterhub-k8s",
+                        "ada2170a2181ae1760d85eab74e5264d0c6bb67f",
+                    )
                 )
             ],
         ),
@@ -85,9 +103,11 @@ from repoproviders.resolvers.git import Git, ImmutableGit
                 "f7f3ff6d1bf708bdc12e5f10e18b2a90a4795603",
             ),
             [
-                ImmutableGit(
-                    "https://github.com/jupyterhub/zero-to-jupyterhub-k8s",
-                    "f7f3ff6d1bf708bdc12e5f10e18b2a90a4795603",
+                MaybeExists(
+                    ImmutableGit(
+                        "https://github.com/jupyterhub/zero-to-jupyterhub-k8s",
+                        "f7f3ff6d1bf708bdc12e5f10e18b2a90a4795603",
+                    )
                 )
             ],
         ),
@@ -96,7 +116,7 @@ from repoproviders.resolvers.git import Git, ImmutableGit
                 "https://github.com/jupyterhub/zero-to-jupyterhub-k8s", "does-not-exist"
             ),
             [
-                NotFound[ImmutableGit](
+                DoesNotExist[ImmutableGit](
                     "No ref does-not-exist found in repo https://github.com/jupyterhub/zero-to-jupyterhub-k8s"
                 )
             ],
@@ -115,22 +135,32 @@ async def test_resolve(url, expected):
         (
             "doi:10.7910/DVN/6ZXAGT/3YRRYJ",
             [
-                Doi(
-                    "https://dataverse.harvard.edu/file.xhtml?persistentId=doi:10.7910/DVN/6ZXAGT/3YRRYJ"
+                Exists(
+                    Doi(
+                        "https://dataverse.harvard.edu/file.xhtml?persistentId=doi:10.7910/DVN/6ZXAGT/3YRRYJ"
+                    )
                 )
             ],
         ),
         # handle schema'd URI
         (
             "hdl:11529/10016",
-            [Doi("https://data.cimmyt.org/dataset.xhtml?persistentId=hdl:11529/10016")],
+            [
+                Exists(
+                    Doi(
+                        "https://data.cimmyt.org/dataset.xhtml?persistentId=hdl:11529/10016"
+                    )
+                )
+            ],
         ),
         # For convenience, we do accept DOIs without a scheme
         (
             "10.7910/DVN/6ZXAGT/3YRRYJ",
             [
-                Doi(
-                    "https://dataverse.harvard.edu/file.xhtml?persistentId=doi:10.7910/DVN/6ZXAGT/3YRRYJ"
+                Exists(
+                    Doi(
+                        "https://dataverse.harvard.edu/file.xhtml?persistentId=doi:10.7910/DVN/6ZXAGT/3YRRYJ"
+                    )
                 )
             ],
         ),
@@ -140,24 +170,30 @@ async def test_resolve(url, expected):
         (
             "https://doi.org/10.7910/DVN/6ZXAGT/3YRRYJ",
             [
-                Doi(
-                    "https://dataverse.harvard.edu/file.xhtml?persistentId=doi:10.7910/DVN/6ZXAGT/3YRRYJ"
+                Exists(
+                    Doi(
+                        "https://dataverse.harvard.edu/file.xhtml?persistentId=doi:10.7910/DVN/6ZXAGT/3YRRYJ"
+                    )
                 )
             ],
         ),
         (
             "https://www.doi.org/10.7910/DVN/6ZXAGT/3YRRYJ",
             [
-                Doi(
-                    "https://dataverse.harvard.edu/file.xhtml?persistentId=doi:10.7910/DVN/6ZXAGT/3YRRYJ"
+                Exists(
+                    Doi(
+                        "https://dataverse.harvard.edu/file.xhtml?persistentId=doi:10.7910/DVN/6ZXAGT/3YRRYJ"
+                    )
                 )
             ],
         ),
         (
             "https://hdl.handle.net/10.7910/DVN/6ZXAGT/3YRRYJ",
             [
-                Doi(
-                    "https://dataverse.harvard.edu/file.xhtml?persistentId=doi:10.7910/DVN/6ZXAGT/3YRRYJ"
+                Exists(
+                    Doi(
+                        "https://dataverse.harvard.edu/file.xhtml?persistentId=doi:10.7910/DVN/6ZXAGT/3YRRYJ"
+                    )
                 )
             ],
         ),
@@ -174,11 +210,15 @@ async def test_norecurse(url, expected):
         (
             "doi:10.7910/DVN/6ZXAGT/3YRRYJ",
             [
-                Doi(
-                    "https://dataverse.harvard.edu/file.xhtml?persistentId=doi:10.7910/DVN/6ZXAGT/3YRRYJ"
+                Exists(
+                    Doi(
+                        "https://dataverse.harvard.edu/file.xhtml?persistentId=doi:10.7910/DVN/6ZXAGT/3YRRYJ"
+                    )
                 ),
-                DataverseDataset(
-                    URL("https://dataverse.harvard.edu"), "doi:10.7910/DVN/6ZXAGT"
+                Exists(
+                    DataverseDataset(
+                        URL("https://dataverse.harvard.edu"), "doi:10.7910/DVN/6ZXAGT"
+                    )
                 ),
             ],
         ),
@@ -186,53 +226,69 @@ async def test_norecurse(url, expected):
         (
             "hdl:11529/10016",
             [
-                Doi(
-                    "https://data.cimmyt.org/dataset.xhtml?persistentId=hdl:11529/10016"
+                Exists(
+                    Doi(
+                        "https://data.cimmyt.org/dataset.xhtml?persistentId=hdl:11529/10016"
+                    )
                 ),
-                DataverseDataset(URL("http://data.cimmyt.org/"), "hdl:11529/10016"),
+                Exists(
+                    DataverseDataset(URL("http://data.cimmyt.org/"), "hdl:11529/10016")
+                ),
             ],
         ),
         # For convenience, we do accept DOIs without a scheme
         (
             "10.7910/DVN/6ZXAGT",
             [
-                Doi(
-                    "https://dataverse.harvard.edu/citation?persistentId=doi:10.7910/DVN/6ZXAGT"
+                Exists(
+                    Doi(
+                        "https://dataverse.harvard.edu/citation?persistentId=doi:10.7910/DVN/6ZXAGT"
+                    )
                 ),
-                DataverseDataset(
-                    URL("https://dataverse.harvard.edu"), "doi:10.7910/DVN/6ZXAGT"
+                Exists(
+                    DataverseDataset(
+                        URL("https://dataverse.harvard.edu"), "doi:10.7910/DVN/6ZXAGT"
+                    )
                 ),
             ],
         ),
         # Something that's only a DOI, and won't resolve further
         (
             "10.1126/science.aar3646",
-            [Doi("https://www.science.org/doi/10.1126/science.aar3646")],
+            [Exists(Doi("https://www.science.org/doi/10.1126/science.aar3646"))],
         ),
         # GitHub URLs that recurse into ImmutableGit
         (
             "https://github.com/jupyterhub/zero-to-jupyterhub-k8s/tree/f7f3ff6d1bf708bdc12e5f10e18b2a90a4795603",
             [
-                Git(
-                    "https://github.com/jupyterhub/zero-to-jupyterhub-k8s",
-                    "f7f3ff6d1bf708bdc12e5f10e18b2a90a4795603",
+                MaybeExists(
+                    Git(
+                        "https://github.com/jupyterhub/zero-to-jupyterhub-k8s",
+                        "f7f3ff6d1bf708bdc12e5f10e18b2a90a4795603",
+                    )
                 ),
-                ImmutableGit(
-                    "https://github.com/jupyterhub/zero-to-jupyterhub-k8s",
-                    "f7f3ff6d1bf708bdc12e5f10e18b2a90a4795603",
+                MaybeExists(
+                    ImmutableGit(
+                        "https://github.com/jupyterhub/zero-to-jupyterhub-k8s",
+                        "f7f3ff6d1bf708bdc12e5f10e18b2a90a4795603",
+                    )
                 ),
             ],
         ),
         (
             "https://github.com/jupyterhub/zero-to-jupyterhub-k8s/tree/0.8.0",
             [
-                Git(
-                    "https://github.com/jupyterhub/zero-to-jupyterhub-k8s",
-                    "0.8.0",
+                MaybeExists(
+                    Git(
+                        "https://github.com/jupyterhub/zero-to-jupyterhub-k8s",
+                        "0.8.0",
+                    )
                 ),
-                ImmutableGit(
-                    "https://github.com/jupyterhub/zero-to-jupyterhub-k8s",
-                    "ada2170a2181ae1760d85eab74e5264d0c6bb67f",
+                Exists(
+                    ImmutableGit(
+                        "https://github.com/jupyterhub/zero-to-jupyterhub-k8s",
+                        "ada2170a2181ae1760d85eab74e5264d0c6bb67f",
+                    )
                 ),
             ],
         ),
@@ -240,78 +296,96 @@ async def test_norecurse(url, expected):
         (
             "git+https://github.com/jupyterhub/zero-to-jupyterhub-k8s@f7f3ff6d1bf708bdc12e5f10e18b2a90a4795603",
             [
-                Git(
-                    "https://github.com/jupyterhub/zero-to-jupyterhub-k8s",
-                    "f7f3ff6d1bf708bdc12e5f10e18b2a90a4795603",
+                MaybeExists(
+                    Git(
+                        "https://github.com/jupyterhub/zero-to-jupyterhub-k8s",
+                        "f7f3ff6d1bf708bdc12e5f10e18b2a90a4795603",
+                    )
                 ),
-                ImmutableGit(
-                    "https://github.com/jupyterhub/zero-to-jupyterhub-k8s",
-                    "f7f3ff6d1bf708bdc12e5f10e18b2a90a4795603",
+                MaybeExists(
+                    ImmutableGit(
+                        "https://github.com/jupyterhub/zero-to-jupyterhub-k8s",
+                        "f7f3ff6d1bf708bdc12e5f10e18b2a90a4795603",
+                    )
                 ),
             ],
         ),
         (
             "git+https://github.com/jupyterhub/zero-to-jupyterhub-k8s@0.8.0",
             [
-                Git(
-                    "https://github.com/jupyterhub/zero-to-jupyterhub-k8s",
-                    "0.8.0",
+                MaybeExists(
+                    Git(
+                        "https://github.com/jupyterhub/zero-to-jupyterhub-k8s",
+                        "0.8.0",
+                    )
                 ),
-                ImmutableGit(
-                    "https://github.com/jupyterhub/zero-to-jupyterhub-k8s",
-                    "ada2170a2181ae1760d85eab74e5264d0c6bb67f",
+                Exists(
+                    ImmutableGit(
+                        "https://github.com/jupyterhub/zero-to-jupyterhub-k8s",
+                        "ada2170a2181ae1760d85eab74e5264d0c6bb67f",
+                    )
                 ),
             ],
         ),
         (
             "10.5281/zenodo.3232985",
             [
-                Doi("https://zenodo.org/record/3232985"),
-                ZenodoDataset(URL("https://zenodo.org/"), "3232985"),
+                Exists(Doi("https://zenodo.org/record/3232985")),
+                MaybeExists(ZenodoDataset(URL("https://zenodo.org/"), "3232985")),
             ],
         ),
         (
             "https://doi.org/10.6084/m9.figshare.9782777.v3",
             [
-                Doi(
-                    "https://figshare.com/articles/Binder-ready_openSenseMap_Analysis/9782777/3"
+                Exists(
+                    Doi(
+                        "https://figshare.com/articles/Binder-ready_openSenseMap_Analysis/9782777/3"
+                    )
                 ),
-                FigshareDataset(
-                    FigshareInstallation(
-                        URL("https://figshare.com/"),
-                        URL("https://api.figshare.com/v2/"),
-                    ),
-                    9782777,
-                    3,
+                MaybeExists(
+                    FigshareDataset(
+                        FigshareInstallation(
+                            URL("https://figshare.com/"),
+                            URL("https://api.figshare.com/v2/"),
+                        ),
+                        9782777,
+                        3,
+                    )
                 ),
-                ImmutableFigshareDataset(
-                    FigshareInstallation(
-                        URL("https://figshare.com/"),
-                        URL("https://api.figshare.com/v2/"),
-                    ),
-                    9782777,
-                    3,
+                MaybeExists(
+                    ImmutableFigshareDataset(
+                        FigshareInstallation(
+                            URL("https://figshare.com/"),
+                            URL("https://api.figshare.com/v2/"),
+                        ),
+                        9782777,
+                        3,
+                    )
                 ),
             ],
         ),
         (
             "https://figshare.com/articles/Binder-ready_openSenseMap_Analysis/9782777",
             [
-                FigshareDataset(
-                    FigshareInstallation(
-                        URL("https://figshare.com/"),
-                        URL("https://api.figshare.com/v2/"),
-                    ),
-                    9782777,
-                    None,
+                MaybeExists(
+                    FigshareDataset(
+                        FigshareInstallation(
+                            URL("https://figshare.com/"),
+                            URL("https://api.figshare.com/v2/"),
+                        ),
+                        9782777,
+                        None,
+                    )
                 ),
-                ImmutableFigshareDataset(
-                    FigshareInstallation(
-                        URL("https://figshare.com/"),
-                        URL("https://api.figshare.com/v2/"),
-                    ),
-                    9782777,
-                    3,
+                Exists(
+                    ImmutableFigshareDataset(
+                        FigshareInstallation(
+                            URL("https://figshare.com/"),
+                            URL("https://api.figshare.com/v2/"),
+                        ),
+                        9782777,
+                        3,
+                    )
                 ),
             ],
         ),
@@ -319,8 +393,8 @@ async def test_norecurse(url, expected):
         (
             "https://doi.org/10.5281/zenodo.805993",
             [
-                Doi(url="https://zenodo.org/doi/10.5281/zenodo.805993"),
-                ZenodoDataset(URL("https://zenodo.org/"), "14007206"),
+                Exists(Doi(url="https://zenodo.org/doi/10.5281/zenodo.805993")),
+                MaybeExists(ZenodoDataset(URL("https://zenodo.org/"), "14007206")),
             ],
         ),
     ),

--- a/tests/resolvers/test_zenodo.py
+++ b/tests/resolvers/test_zenodo.py
@@ -42,8 +42,9 @@ from repoproviders.resolvers.doi import ZenodoDataset, ZenodoResolver
         # A doi reference to a bad doi
         (
             "https://zenodo.org/doi/10.5281/zdo.805993",
-            DoesNotExist[ZenodoDataset](
-                "https://zenodo.org/doi/10.5281/zdo.805993 is not a valid Zenodo DOI URL"
+            DoesNotExist(
+                ZenodoDataset,
+                "https://zenodo.org/doi/10.5281/zdo.805993 is not a valid Zenodo DOI URL",
             ),
         ),
     ),

--- a/tests/resolvers/test_zenodo.py
+++ b/tests/resolvers/test_zenodo.py
@@ -1,7 +1,7 @@
 import pytest
 from yarl import URL
 
-from repoproviders.resolvers.base import NotFound
+from repoproviders.resolvers.base import DoesNotExist, MaybeExists
 from repoproviders.resolvers.doi import ZenodoDataset, ZenodoResolver
 
 
@@ -14,35 +14,35 @@ from repoproviders.resolvers.doi import ZenodoDataset, ZenodoResolver
         # Simple /record and /records
         (
             "https://zenodo.org/record/3232985",
-            ZenodoDataset(URL("https://zenodo.org/"), "3232985"),
+            MaybeExists(ZenodoDataset(URL("https://zenodo.org/"), "3232985")),
         ),
         (
             "https://zenodo.org/records/3232985",
-            ZenodoDataset(URL("https://zenodo.org/"), "3232985"),
+            MaybeExists(ZenodoDataset(URL("https://zenodo.org/"), "3232985")),
         ),
         # Note we normalize output to have the HTTPS URL, even if we're passed in the HTTP URL
         (
             "http://zenodo.org/record/3232985",
-            ZenodoDataset(URL("https://zenodo.org/"), "3232985"),
+            MaybeExists(ZenodoDataset(URL("https://zenodo.org/"), "3232985")),
         ),
         (
             "https://zenodo.org/records/3232985",
-            ZenodoDataset(URL("https://zenodo.org/"), "3232985"),
+            MaybeExists(ZenodoDataset(URL("https://zenodo.org/"), "3232985")),
         ),
         # A non-zenodo URL
         (
             "https://data.caltech.edu/records/996aw-mf266",
-            ZenodoDataset(URL("https://data.caltech.edu/"), "996aw-mf266"),
+            MaybeExists(ZenodoDataset(URL("https://data.caltech.edu/"), "996aw-mf266")),
         ),
         # A doi reference
         (
             "https://zenodo.org/doi/10.5281/zenodo.805993",
-            ZenodoDataset(URL("https://zenodo.org/"), recordId="14007206"),
+            MaybeExists(ZenodoDataset(URL("https://zenodo.org/"), recordId="14007206")),
         ),
         # A doi reference to a bad doi
         (
             "https://zenodo.org/doi/10.5281/zdo.805993",
-            NotFound[ZenodoDataset](
+            DoesNotExist[ZenodoDataset](
                 "https://zenodo.org/doi/10.5281/zdo.805993 is not a valid Zenodo DOI URL"
             ),
         ),


### PR DESCRIPTION
Inspired by how Rust does these ([Result](https://doc.rust-lang.org/std/result/) etc), there are now generic wrapper types for representing the three different kinds of results individual resolvers may return:

1. I have *guessed* this thing exists, based on what was passed in to me (URL or other repo)
2. I have *checked* and know this thing exists, based on talking to an external source of truth (API, etc)
3. I have *checked* and know this thing *does not exist*, based on talking to an external source of truth (API, etc)
4. Idk what this is (`None`)

These types either wrap an actual `Repo` object, or for `NotFound` the type of `Repo` it was. Ideally we would be able to represent these purely as the generics, but turns out it's not *really* possible to get direct answers about the generic type of an instantiated class at runtime (`typing.get_args` notwithstanding). 

This helps each method communicate both the level of certainity it has as well as the thing it has found itself in a nice neat package.

Also allows us to eventually implement a `find` mechanism or similar that can take a `MaybeExists` and try to turn it into a `Exists` or `DoesNotExist`, as existence checks are often reasonably simple.

During this process I also realized a few things were returning `NotFound` when they should have been returning `None` so that has been fixed.

Also the first time I'm really using python's `match case`!

- Sets minimum python version to 3.12, so I can use all the new syntax