### PR TITLE
Add GitLab resolvers for both gitlab.com and any gitlab install

### DIFF
--- a/src/repoproviders/resolvers/git.py
+++ b/src/repoproviders/resolvers/git.py
@@ -43,6 +43,12 @@ class GitLabResolver:
             )
         elif "-" in parts:
             dash_index = parts.index("-")
+            if len(parts) == dash_index + 1:
+                # The dash is the last part of the URL, which isn't something we recognize to be anything
+                return None
+            if not parts[dash_index + 1] in ("tree", "blob"):
+                # GitLab has dashes in lots of URLs, we only care about tree and blob ones
+                return None
             return MaybeExists(
                 Git(
                     str(url.with_path("/".join(parts[0:dash_index]))),

--- a/src/repoproviders/resolvers/git.py
+++ b/src/repoproviders/resolvers/git.py
@@ -4,7 +4,7 @@ import re
 from yarl import URL
 
 from .base import DoesNotExist, Exists, MaybeExists
-from .repos import Git, GitHubURL, ImmutableGit
+from .repos import Git, GitHubURL, GitLabURL, ImmutableGit
 
 
 class GitHubResolver:
@@ -26,6 +26,31 @@ class GitHubResolver:
             )
         else:
             # This is not actually a valid GitHub URL we support
+            return None
+
+
+class GitLabResolver:
+    async def resolve(self, question: GitLabURL) -> MaybeExists[Git] | None:
+        url = question.url
+        # Split the URL into parts, discarding empty parts to account for leading and trailing slashes
+        parts = [p for p in url.path.split("/") if p.strip() != ""]
+        if len(parts) in (2, 3):
+            # Handle <user|org>/<repo> as well as <user|org>/<namespace>/<repo>
+            # Reconstruct the URL so we normalize any
+            return MaybeExists(
+                # Clear out the URL to remove query params & fragments
+                Git(repo=str(url.with_query(None).with_fragment(None)), ref="HEAD")
+            )
+        elif "-" in parts:
+            dash_index = parts.index("-")
+            return MaybeExists(
+                Git(
+                    str(url.with_path("/".join(parts[0:dash_index]))),
+                    parts[dash_index + 2],
+                )
+            )
+        else:
+            # This is not actually a valid GitLab URL we support
             return None
 
 

--- a/src/repoproviders/resolvers/repos.py
+++ b/src/repoproviders/resolvers/repos.py
@@ -43,6 +43,21 @@ class GitHubURL:
 
 
 @dataclass(frozen=True)
+class GitLabURL:
+    """
+    A GitLab URL of any sort.
+
+    Not just a repository URL.
+    """
+
+    installation: URL
+    url: URL
+
+    # URLs can point to whatever
+    immutable = False
+
+
+@dataclass(frozen=True)
 class Doi:
     url: URL
 

--- a/src/repoproviders/resolvers/resolver.py
+++ b/src/repoproviders/resolvers/resolver.py
@@ -15,13 +15,14 @@ from .doi import (
     ImmutableFigshareResolver,
     ZenodoResolver,
 )
-from .git import GitHubResolver, GitUrlResolver, ImmutableGitResolver
+from .git import GitHubResolver, GitLabResolver, GitUrlResolver, ImmutableGitResolver
 from .wellknown import WellKnownProvidersResolver
 
 ALL_RESOLVERS: list[SupportsResolve] = [
     WellKnownProvidersResolver(),
     GitHubResolver(),
     GitUrlResolver(),
+    GitLabResolver(),
     DoiResolver(),
     ZenodoResolver(),
     FigshareResolver(),

--- a/src/repoproviders/resolvers/wellknown.py
+++ b/src/repoproviders/resolvers/wellknown.py
@@ -11,6 +11,7 @@ from .repos import (
     FigshareInstallation,
     FigshareURL,
     GitHubURL,
+    GitLabURL,
     ZenodoURL,
 )
 
@@ -25,6 +26,16 @@ class WellKnownProvidersResolver:
             return None
         else:
             return GitHubURL(URL("https://github.com"), question)
+
+    def detect_gitlab(self, question: URL) -> GitLabURL | None:
+        # git+<scheme> urls are handled by a different resolver
+        if question.scheme not in ("http", "https") or (
+            question.host != "gitlab.com" and question.host != "www.gitlab.com"
+        ):
+            # TODO: Allow configuring for GitHub enterprise
+            return None
+        else:
+            return GitLabURL(URL("https://gitlab.com"), question)
 
     def detect_zenodo(self, question: URL) -> ZenodoURL | None:
         KNOWN_INSTALLATIONS = [
@@ -115,6 +126,7 @@ class WellKnownProvidersResolver:
             self.detect_dataverse,
             self.detect_zenodo,
             self.detect_figshare,
+            self.detect_gitlab,
         ]
 
         match question:

--- a/tests/resolvers/test_gitlab.py
+++ b/tests/resolvers/test_gitlab.py
@@ -1,0 +1,124 @@
+import pytest
+from yarl import URL
+
+from repoproviders.resolvers.base import MaybeExists
+from repoproviders.resolvers.git import Git, GitLabResolver
+from repoproviders.resolvers.repos import GitLabURL
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    (
+        # GitLab URLs that are not repos
+        (
+            GitLabURL(URL("https://gitlab.com"), URL("https://gitlab.com/mosaik/")),
+            None,
+        ),
+        (
+            GitLabURL(
+                URL("https://gitlab.com"),
+                URL("https://gitlab.com/groups/mosaik/-/packages"),
+            ),
+            None,
+        ),
+        (
+            GitLabURL(
+                URL("https://gitlab.com"),
+                # Put a - at the end to test for edge cases
+                URL("https://gitlab.com/groups/mosaik/something/something/-"),
+            ),
+            None,
+        ),
+        (
+            GitLabURL(
+                URL("https://gitlab.com"),
+                URL("https://gitlab.com/mosaik/mosaik/-/merge_requests/194"),
+            ),
+            None,
+        ),
+        # Simple GitLab repo URL
+        (
+            GitLabURL(
+                URL("https://gitlab.com"), URL("https://gitlab.com/mosaik/mosaik")
+            ),
+            MaybeExists(Git("https://gitlab.com/mosaik/mosaik", "HEAD")),
+        ),
+        # blobs and tree
+        (
+            GitLabURL(
+                URL("https://gitlab.com"),
+                URL(
+                    "https://gitlab.com/mosaik/examples/mosaik-tutorials-on-binder/-/blob/b2c44e7f804dc1634681540582b1731e0393f69b/03_Same_Time_Loop/_01_controller_master.ipynb?ref_type=heads"
+                ),
+            ),
+            MaybeExists(
+                Git(
+                    "https://gitlab.com/mosaik/examples/mosaik-tutorials-on-binder",
+                    "b2c44e7f804dc1634681540582b1731e0393f69b",
+                )
+            ),
+        ),
+        (
+            GitLabURL(
+                URL("https://gitlab.com"),
+                URL(
+                    "https://gitlab.com/mosaik/examples/mosaik-tutorials-on-binder/-/tree/b2c44e7f804dc1634681540582b1731e0393f69b/03_Same_Time_Loop?ref_type=heads"
+                ),
+            ),
+            MaybeExists(
+                Git(
+                    "https://gitlab.com/mosaik/examples/mosaik-tutorials-on-binder",
+                    "b2c44e7f804dc1634681540582b1731e0393f69b",
+                )
+            ),
+        ),
+        (
+            GitLabURL(
+                URL("https://gitlab.wikimedia.org"),
+                URL(
+                    "https://gitlab.wikimedia.org/toolforge-repos/toolviews/-/tree/main/toolviews?ref_type=heads"
+                ),
+            ),
+            MaybeExists(
+                Git("https://gitlab.wikimedia.org/toolforge-repos/toolviews", "main")
+            ),
+        ),
+        (
+            GitLabURL(
+                URL("https://gitlab.wikimedia.org"),
+                URL(
+                    "https://gitlab.wikimedia.org/toolforge-repos/toolviews/-/blob/main/toolviews/__init__.py?ref_type=heads"
+                ),
+            ),
+            MaybeExists(
+                Git("https://gitlab.wikimedia.org/toolforge-repos/toolviews", "main")
+            ),
+        ),
+        (
+            GitLabURL(
+                URL("https://gitlab.com"),
+                URL(
+                    "https://gitlab.com/mosaik/examples/mosaik-tutorials-on-binder/-/tree/b2c44e7f804dc1634681540582b1731e0393f69b/03_Same_Time_Loop?ref_type=heads"
+                ),
+            ),
+            MaybeExists(
+                Git(
+                    "https://gitlab.com/mosaik/examples/mosaik-tutorials-on-binder",
+                    "b2c44e7f804dc1634681540582b1731e0393f69b",
+                )
+            ),
+        ),
+        (
+            GitLabURL(
+                URL("https://gitlab.com"),
+                URL("https://gitlab.com/yuvipanda/does-not-exist-e43"),
+            ),
+            MaybeExists(
+                Git(repo="https://gitlab.com/yuvipanda/does-not-exist-e43", ref="HEAD")
+            ),
+        ),
+    ),
+)
+async def test_gitlab(url, expected):
+    gl = GitLabResolver()
+    assert await gl.resolve(url) == expected

--- a/tests/resolvers/test_gitlab.py
+++ b/tests/resolvers/test_gitlab.py
@@ -117,6 +117,16 @@ from repoproviders.resolvers.repos import GitLabURL
                 Git(repo="https://gitlab.com/yuvipanda/does-not-exist-e43", ref="HEAD")
             ),
         ),
+        # Non repo URLs should simply be detected to be not a repo
+        (
+            GitLabURL(
+                URL("https://gitlab.wikimedia.org"),
+                URL(
+                    "https://gitlab.wikimedia.org/toolforge-repos/toolviews/-/merge_requests/11"
+                ),
+            ),
+            None,
+        ),
     ),
 )
 async def test_gitlab(url, expected):

--- a/tests/resolvers/test_resolve.py
+++ b/tests/resolvers/test_resolve.py
@@ -3,7 +3,6 @@ from yarl import URL
 
 from repoproviders.resolvers import resolve
 from repoproviders.resolvers.base import DoesNotExist, Exists, MaybeExists
-from repoproviders.resolvers.git import Git, ImmutableGit
 from repoproviders.resolvers.repos import (
     DataverseDataset,
     DataverseURL,
@@ -11,8 +10,11 @@ from repoproviders.resolvers.repos import (
     FigshareDataset,
     FigshareInstallation,
     FigshareURL,
+    Git,
     GitHubURL,
+    GitLabURL,
     ImmutableFigshareDataset,
+    ImmutableGit,
     ZenodoDataset,
     ZenodoURL,
 )
@@ -590,6 +592,58 @@ async def test_norecurse(url, expected):
                 Exists(
                     DataverseDataset(
                         URL("https://demo.dataverse.org"), "doi:10.70122/FK2/MBQA9G"
+                    )
+                ),
+            ],
+        ),
+        # A GitLab URL on GitLab
+        (
+            "https://gitlab.com/mosaik/examples/mosaik-tutorials-on-binder/-/blob/b2c44e7f804dc1634681540582b1731e0393f69b/03_Same_Time_Loop/_01_controller_master.ipynb?ref_type=heads",
+            [
+                MaybeExists(
+                    repo=GitLabURL(
+                        installation=URL("https://gitlab.com"),
+                        url=URL(
+                            "https://gitlab.com/mosaik/examples/mosaik-tutorials-on-binder/-/blob/b2c44e7f804dc1634681540582b1731e0393f69b/03_Same_Time_Loop/_01_controller_master.ipynb?ref_type=heads"
+                        ),
+                    )
+                ),
+                MaybeExists(
+                    repo=Git(
+                        repo="https://gitlab.com/mosaik/examples/mosaik-tutorials-on-binder",
+                        ref="b2c44e7f804dc1634681540582b1731e0393f69b",
+                    )
+                ),
+                MaybeExists(
+                    repo=ImmutableGit(
+                        repo="https://gitlab.com/mosaik/examples/mosaik-tutorials-on-binder",
+                        ref="b2c44e7f804dc1634681540582b1731e0393f69b",
+                    )
+                ),
+            ],
+        ),
+        # A GitLab URL that isn't on gitlab.com
+        (
+            "https://gitlab.wikimedia.org/toolforge-repos/toolviews/-/tree/bb42ab4dc4ddf0712f83ec4add58005a3ae75de5/toolviews?ref_type=heads",
+            [
+                MaybeExists(
+                    repo=GitLabURL(
+                        installation=URL("https://gitlab.wikimedia.org/"),
+                        url=URL(
+                            "https://gitlab.wikimedia.org/toolforge-repos/toolviews/-/tree/bb42ab4dc4ddf0712f83ec4add58005a3ae75de5/toolviews?ref_type=heads"
+                        ),
+                    )
+                ),
+                MaybeExists(
+                    repo=Git(
+                        repo="https://gitlab.wikimedia.org/toolforge-repos/toolviews",
+                        ref="bb42ab4dc4ddf0712f83ec4add58005a3ae75de5",
+                    )
+                ),
+                MaybeExists(
+                    repo=ImmutableGit(
+                        repo="https://gitlab.wikimedia.org/toolforge-repos/toolviews",
+                        ref="bb42ab4dc4ddf0712f83ec4add58005a3ae75de5",
                     )
                 ),
             ],

--- a/tests/resolvers/test_wellknown.py
+++ b/tests/resolvers/test_wellknown.py
@@ -8,6 +8,7 @@ from repoproviders.resolvers.repos import (
     FigshareInstallation,
     FigshareURL,
     GitHubURL,
+    GitLabURL,
     ZenodoURL,
 )
 from repoproviders.resolvers.wellknown import WellKnownProvidersResolver
@@ -73,6 +74,12 @@ from repoproviders.resolvers.wellknown import WellKnownProvidersResolver
                     ),
                     URL("https://figshare.com/browse"),
                 )
+            ),
+        ),
+        (
+            "https://gitlab.com/browse",
+            MaybeExists(
+                GitLabURL(URL("https://gitlab.com"), URL("https://gitlab.com/browse"))
             ),
         ),
     ),


### PR DESCRIPTION
By adding a section to both wellknown resolver and to the feature detect resolver, we can easily resolve both gitlab.com as well as any other GitLab installation without having to know what it is beforehand!

This is a test to demonstrate the scalability (in the 'open to future change without a lot of work') nature of this design
