### PR TITLE
Handle main zenodo download case better

### DIFF
--- a/src/repoproviders/fetchers/zenodo.py
+++ b/src/repoproviders/fetchers/zenodo.py
@@ -5,7 +5,6 @@ from tempfile import NamedTemporaryFile
 from zipfile import ZipFile
 
 import aiohttp
-from yarl import URL
 
 from ..resolvers.doi import ZenodoDataset
 from ..utils import download_file
@@ -29,10 +28,7 @@ class ZenodoFetcher:
                 # Only do this if mimetype is zip
                 entry = data["entries"][0]
                 if entry["mimetype"] == "application/zip":
-                    download_api_url = entry["links"]["content"]
-
-                    download_url_resp = await session.get(download_api_url)
-                    download_url = URL(await download_url_resp.text())
+                    download_url = entry["links"]["content"]
 
                     with NamedTemporaryFile() as temp_file:
                         await download_file(session, download_url, Path(temp_file.name))

--- a/src/repoproviders/utils.py
+++ b/src/repoproviders/utils.py
@@ -9,6 +9,12 @@ async def download_file(session: aiohttp.ClientSession, url: URL, output_path: P
     CHUNK_SIZE = 4 * 1024
     resp = await session.get(url)
 
+    if resp.status == 200 and "Location" in resp.headers:
+        # Some providers (lookin at you, data.caltech.edu) send a Location header
+        # *but with a 200 status code*. This is invalid and bogus, yet we have to
+        # honor it. Sigh
+        return await download_file(session, URL(resp.headers["Location"]), output_path)
+
     resp.raise_for_status()
 
     if not output_path.parent.exists():

--- a/tests/fetchers/test_zenodo.py
+++ b/tests/fetchers/test_zenodo.py
@@ -13,7 +13,8 @@ from repoproviders.resolvers.base import DoesNotExist
     ("questions", "md5tree"),
     [
         (
-            # Test fetching a record with a single zip file that we then extract
+            # Test fetching a record with a single zip file that we then extract,
+            # Also accounting for data.caltech.edu sending back 200 response with Location headers
             ("https://data.caltech.edu/records/996aw-mf266",),
             {
                 "CaltechDATA_Usage_Graphs.ipynb": "3bb3a97b879112b1ab70923636d63e87",
@@ -22,6 +23,16 @@ from repoproviders.resolvers.base import DoesNotExist
                 "README.md": "59a0e5157faef752532fe51a2d490c9c",
                 ".gitignore": "2a9ac83919f923cc25ea380b19a2a7d9",
                 "codemeta.json": "8aa017724932fbdff3d2240c932487b7",
+            },
+        ),
+        (
+            # Test fetching a record with a single zip file, without the 200 / Location header
+            # issue
+            ("https://sandbox.zenodo.org/records/432153",),
+            {
+                "LICENSE": "65d3616852dbf7b1a6d4b53b00626032",
+                "README.md": "041917c62158f2dec74eb1ead07662f1",
+                "rutgers.txt": "2f501f69915cbcf0fb185f9e8bdb1c96",
             },
         ),
         (


### PR DESCRIPTION
The caltech instance responds to requests with a 2xx and Location header, which the main zenodo instance doesn't. Handle this case.