### PR TITLE
Don't test on both python 3.12 and 3.13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.13"]
+        python-version: ["3.12"]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
This doubles our test time and wastes resources. Let's just test on 3.12 for now.