### PR TITLE
Fallback to what we use for hashing more elegantly

### DIFF
--- a/src/repoproviders/resolvers/rclone.py
+++ b/src/repoproviders/resolvers/rclone.py
@@ -72,7 +72,7 @@ class GoogleDriveFolderResolver:
             hash_input = {}
             for item in data:
                 # Use (in order of preference), sha256, sha1, md5 and modtime based on what is present
-                hashes = item.get("Hashes")
+                hashes = item.get("Hashes", {})
                 h = hashes.get(
                     "sha256", hashes.get("sha1", hashes.get("md5", item["ModTime"]))
                 )


### PR DESCRIPTION
Older versions of rclone don't give us sha256 by default, and we handle those better
